### PR TITLE
Mounting the volume without rebuilding the crew-fe image

### DIFF
--- a/crew/fe/Dockerfile
+++ b/crew/fe/Dockerfile
@@ -1,2 +1,0 @@
-FROM nginx
-COPY . /usr/share/nginx/html/

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -73,7 +73,9 @@ services:
       retries: 4
 
   crew-fe:
-    build: "./crew/fe"
+    image: nginx
+    volumes:
+      - ./crew/fe:/usr/share/nginx/html/
     ports:
       - 9980:80
     depends_on:


### PR DESCRIPTION
Removing the copy command in the Dockerfile eliminates the need to rebuild the container. (Spoiler) The missing_note is displayed directly in the browser after a reload of the page. 

Since the Dockerfile was otherwise empty, it was removed in the process and the image was included in the Docker-compose, along with the volume mount. 